### PR TITLE
chore: Add documentation for MultiElementWrapper's get method

### DIFF
--- a/packages/core/src/selectors.ts
+++ b/packages/core/src/selectors.ts
@@ -56,6 +56,9 @@ export class MultiElementWrapper<T extends AbstractWrapper> extends ElementWrapp
     super(root);
   }
 
+  /**
+   * Index is one-based because the method uses the :nth-child() CSS pseudo-class.
+   */
   get(index: number): T {
     return this.elementFactory(`${this.root}:nth-child(${index})`);
   }


### PR DESCRIPTION
*Issue #, if available:* AWSUI-19977

*Description of changes:*

We got many customer questions why this method uses one-based
indices. Documenting this and explaining the reason makes
that explicit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
