### PR TITLE
fix: remove react from peerDependencies

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -10,9 +10,6 @@
       "dependencies": {
         "css-selector-tokenizer": "^0.8.0",
         "css.escape": "^1.5.1"
-      },
-      "peerDependencies": {
-        "react-dom": "^16.8 || ^17 || ^18"
       }
     },
     "node_modules/css-selector-tokenizer": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,9 +22,6 @@
     "css-selector-tokenizer": "^0.8.0",
     "css.escape": "^1.5.1"
   },
-  "peerDependencies": {
-    "react-dom": "^16.8 || ^17 || ^18"
-  },
   "jest": {
     "preset": "ts-jest",
     "globals": {


### PR DESCRIPTION
Adding that declaration caused a 2nd copy of react to be installed in some cases. This declaration does not help us with anything, because this library is only used in React projects anyway, but it causes confusion for npm, so better to remove it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
