### PR TITLE
chore: Use codecov upload token

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -16,3 +16,4 @@ permissions:
 jobs:
   build:
     uses: cloudscape-design/.github/.github/workflows/build-lint-test.yml@main
+    secrets: inherit


### PR DESCRIPTION
Allow the build workflow to inherit secrets so that the `CODECOV_TOKEN` can be access by the codecov action. See https://github.com/cloudscape-design/.github/pull/48.

Related links, issue #, if available: AWSUI-20481


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
