### PR TITLE
chore: Fix deprecated `act` usage for React 18 

### DIFF
--- a/src/core/dom.ts
+++ b/src/core/dom.ts
@@ -1,9 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 /*eslint-env browser*/
-import { act } from 'react-dom/test-utils';
+import * as React from 'react';
+import { act as reactDomAct } from 'react-dom/test-utils';
 import { IElementWrapper } from './interfaces';
 import { KeyCode, isScopedSelector, substituteScope } from './utils';
+const act = ('act' in React ? React.act : reactDomAct) as typeof reactDomAct;
 
 // Original KeyboardEventInit lacks some properties https://github.com/Microsoft/TypeScript/issues/15228
 declare global {


### PR DESCRIPTION
Resolves https://github.com/cloudscape-design/test-utils/issues/54

*Description of changes:* 
Fixes deprecated `act` usage for React 18 while keeping compatibility with React 16 and 17.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
