### PR TITLE
fix: Add react to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "css-selector-tokenizer": "^0.8.0",
         "css.escape": "^1.5.1",
         "glob": "^7.2.0",
+        "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
@@ -4984,7 +4985,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "css-selector-tokenizer": "^0.8.0",
     "css.escape": "^1.5.1",
     "glob": "^7.2.0",
+    "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This [commit](https://github.com/cloudscape-design/test-utils/commit/83af7522ab13aab8fc31a4178fbfb639db1ad70b) introduced direct usage of React and react is not listed in dependencies. This can cause some consumers to fail because they may not have `react` as dependency, so they will have an error like 
```
Error: Webpack Compilation Error
Module not found: Error: Can't resolve 'react'
Module not found: Error: Can't resolve 'react-dom/test-utils'
```
This happened with my integration tests. My commit should fix this issue.

*Description of changes:*
- Add react to dependencies

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
