### PR TITLE
feat: Add findAll with testindex support

### DIFF
--- a/src/converter/test/__snapshots__/converter.test.ts.snap
+++ b/src/converter/test/__snapshots__/converter.test.ts.snap
@@ -15,6 +15,11 @@ export default class DummyWrapper extends ComponentWrapper {
   findChildren() {
     return this.findAll('.awsui-element').map(element => new ChildWrapper(element.getElement()));
   }
+  findChildrenWithTestindex() {
+    return this.findAll('.awsui-element', {
+      useTestindex: true
+    }).map(element => new ChildWrapper(element.getElement()));
+  }
 }"
 `;
 

--- a/src/converter/test/inputs/converter/multi.ts
+++ b/src/converter/test/inputs/converter/multi.ts
@@ -15,4 +15,10 @@ export default class DummyWrapper extends ComponentWrapper {
   findChildren(): Array<ChildWrapper> {
     return this.findAll('.awsui-element').map(element => new ChildWrapper(element.getElement()));
   }
+
+  findChildrenWithTestindex(): Array<ChildWrapper> {
+    return this.findAll('.awsui-element', { useTestindex: true }).map(
+      element => new ChildWrapper(element.getElement())
+    );
+  }
 }

--- a/src/core/dom.ts
+++ b/src/core/dom.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 /*eslint-env browser*/
-import { IElementWrapper } from './interfaces';
+import { IElementWrapper, MultiElementWrapperOptions } from './interfaces';
 import { KeyCode, isScopedSelector, substituteScope } from './utils';
 import { act } from './utils-dom';
 
@@ -97,7 +97,10 @@ export class AbstractWrapper<ElementType extends Element>
     return this.element.matches(selector) ? this : null;
   }
 
-  findAll<NewElementType extends Element = HTMLElement>(selector: string) {
+  // Declaring options so that the method signature between dom and selectors is aligned.
+  // The options property is only used in the selectors wrapper.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  findAll<NewElementType extends Element = HTMLElement>(selector: string, options?: MultiElementWrapperOptions) {
     let elements: Array<NewElementType>;
     if (isScopedSelector(selector)) {
       const randomValue = Math.floor(Math.random() * 100000);

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -7,5 +7,9 @@ export interface IElementWrapper<ElementType, CollectionType> {
 
   find(selector: string): IElementWrapper<ElementType, CollectionType> | null;
 
-  findAll(selector: string): CollectionType;
+  findAll(selector: string, options?: MultiElementWrapperOptions): CollectionType;
+}
+
+export interface MultiElementWrapperOptions {
+  useTestindex?: boolean;
 }

--- a/src/core/test/__snapshots__/documenter.test.ts.snap
+++ b/src/core/test/__snapshots__/documenter.test.ts.snap
@@ -56,6 +56,13 @@ Note that programmatic events ignore disabled attribute and will trigger listene
             "name": "selector",
             "typeName": "string",
           },
+          {
+            "flags": {
+              "isOptional": true,
+            },
+            "name": "options",
+            "typeName": "MultiElementWrapperOptions",
+          },
         ],
         "returnType": {
           "name": "array",
@@ -280,6 +287,13 @@ Note that programmatic events ignore disabled attribute and will trigger listene
             },
             "name": "selector",
             "typeName": "string",
+          },
+          {
+            "flags": {
+              "isOptional": true,
+            },
+            "name": "options",
+            "typeName": "MultiElementWrapperOptions",
           },
         ],
         "returnType": {
@@ -535,6 +549,13 @@ Note that programmatic events ignore disabled attribute and will trigger listene
             },
             "name": "selector",
             "typeName": "string",
+          },
+          {
+            "flags": {
+              "isOptional": true,
+            },
+            "name": "options",
+            "typeName": "MultiElementWrapperOptions",
           },
         ],
         "returnType": {
@@ -758,6 +779,13 @@ exports[`documenter output > selectors 1`] = `
             "name": "selector",
             "typeName": "string",
           },
+          {
+            "flags": {
+              "isOptional": true,
+            },
+            "name": "options",
+            "typeName": "MultiElementWrapperOptions",
+          },
         ],
         "returnType": {
           "name": "MultiElementWrapper",
@@ -898,6 +926,13 @@ exports[`documenter output > selectors 1`] = `
             },
             "name": "selector",
             "typeName": "string",
+          },
+          {
+            "flags": {
+              "isOptional": true,
+            },
+            "name": "options",
+            "typeName": "MultiElementWrapperOptions",
           },
         ],
         "returnType": {
@@ -1058,6 +1093,13 @@ exports[`documenter output > selectors 1`] = `
             "name": "selector",
             "typeName": "string",
           },
+          {
+            "flags": {
+              "isOptional": true,
+            },
+            "name": "options",
+            "typeName": "MultiElementWrapperOptions",
+          },
         ],
         "returnType": {
           "name": "MultiElementWrapper",
@@ -1217,6 +1259,13 @@ exports[`documenter output > selectors 1`] = `
             "name": "selector",
             "typeName": "string",
           },
+          {
+            "flags": {
+              "isOptional": true,
+            },
+            "name": "options",
+            "typeName": "MultiElementWrapperOptions",
+          },
         ],
         "returnType": {
           "name": "MultiElementWrapper",
@@ -1299,7 +1348,7 @@ exports[`documenter output > selectors 1`] = `
         },
       },
       {
-        "description": "Index is one-based because the method uses the :nth-child() CSS pseudo-class.",
+        "description": "Index is one-based.",
         "name": "get",
         "parameters": [
           {


### PR DESCRIPTION
Extends findAll to match elements by data-testindex instead of :nth-child().

Rel: [4QRKAKIJD3RX]

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
