### PR TITLE
feat: adds findAllComponents selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@cloudscape-design/test-utils-monorepo",
       "version": "1.0.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.0",
         "@babel/plugin-syntax-decorators": "^7.16.0",

--- a/src/core/test/__snapshots__/documenter.test.ts.snap
+++ b/src/core/test/__snapshots__/documenter.test.ts.snap
@@ -79,6 +79,39 @@ Note that programmatic events ignore disabled attribute and will trigger listene
         },
       },
       {
+        "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+        "name": "findAllComponents",
+        "parameters": [
+          {
+            "description": "
+Component's wrapper class",
+            "flags": {
+              "isOptional": false,
+            },
+            "name": "ComponentClass",
+            "typeName": "ComponentWrapperClass",
+          },
+          {
+            "flags": {
+              "isOptional": true,
+            },
+            "name": "selector",
+          },
+        ],
+        "returnType": {
+          "name": "Array",
+          "type": "reference",
+          "typeArguments": [
+            {
+              "name": "Wrapper",
+              "type": "typeParameter",
+            },
+          ],
+        },
+      },
+      {
         "name": "findByClassName",
         "parameters": [
           {
@@ -95,9 +128,15 @@ Note that programmatic events ignore disabled attribute and will trigger listene
         },
       },
       {
+        "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.
+",
         "name": "findComponent",
         "parameters": [
           {
+            "description": "
+CSS selector",
             "flags": {
               "isOptional": false,
             },
@@ -105,10 +144,13 @@ Note that programmatic events ignore disabled attribute and will trigger listene
             "typeName": "string",
           },
           {
+            "description": "
+Component's wrapper class",
             "flags": {
               "isOptional": false,
             },
             "name": "ComponentClass",
+            "typeName": "WrapperClass",
           },
         ],
         "returnType": {
@@ -307,6 +349,42 @@ Note that programmatic events ignore disabled attribute and will trigger listene
         },
       },
       {
+        "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+        "inheritedFrom": {
+          "name": "AbstractWrapper.findAllComponents",
+        },
+        "name": "findAllComponents",
+        "parameters": [
+          {
+            "description": "
+Component's wrapper class",
+            "flags": {
+              "isOptional": false,
+            },
+            "name": "ComponentClass",
+            "typeName": "ComponentWrapperClass",
+          },
+          {
+            "flags": {
+              "isOptional": true,
+            },
+            "name": "selector",
+          },
+        ],
+        "returnType": {
+          "name": "Array",
+          "type": "reference",
+          "typeArguments": [
+            {
+              "name": "Wrapper",
+              "type": "typeParameter",
+            },
+          ],
+        },
+      },
+      {
         "inheritedFrom": {
           "name": "AbstractWrapper.findByClassName",
         },
@@ -326,12 +404,18 @@ Note that programmatic events ignore disabled attribute and will trigger listene
         },
       },
       {
+        "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.
+",
         "inheritedFrom": {
           "name": "AbstractWrapper.findComponent",
         },
         "name": "findComponent",
         "parameters": [
           {
+            "description": "
+CSS selector",
             "flags": {
               "isOptional": false,
             },
@@ -339,10 +423,13 @@ Note that programmatic events ignore disabled attribute and will trigger listene
             "typeName": "string",
           },
           {
+            "description": "
+Component's wrapper class",
             "flags": {
               "isOptional": false,
             },
             "name": "ComponentClass",
+            "typeName": "WrapperClass",
           },
         ],
         "returnType": {
@@ -562,6 +649,42 @@ Note that programmatic events ignore disabled attribute and will trigger listene
         },
       },
       {
+        "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+        "inheritedFrom": {
+          "name": "AbstractWrapper.findAllComponents",
+        },
+        "name": "findAllComponents",
+        "parameters": [
+          {
+            "description": "
+Component's wrapper class",
+            "flags": {
+              "isOptional": false,
+            },
+            "name": "ComponentClass",
+            "typeName": "ComponentWrapperClass",
+          },
+          {
+            "flags": {
+              "isOptional": true,
+            },
+            "name": "selector",
+          },
+        ],
+        "returnType": {
+          "name": "Array",
+          "type": "reference",
+          "typeArguments": [
+            {
+              "name": "Wrapper",
+              "type": "typeParameter",
+            },
+          ],
+        },
+      },
+      {
         "inheritedFrom": {
           "name": "AbstractWrapper.findByClassName",
         },
@@ -581,12 +704,18 @@ Note that programmatic events ignore disabled attribute and will trigger listene
         },
       },
       {
+        "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.
+",
         "inheritedFrom": {
           "name": "AbstractWrapper.findComponent",
         },
         "name": "findComponent",
         "parameters": [
           {
+            "description": "
+CSS selector",
             "flags": {
               "isOptional": false,
             },
@@ -594,10 +723,13 @@ Note that programmatic events ignore disabled attribute and will trigger listene
             "typeName": "string",
           },
           {
+            "description": "
+Component's wrapper class",
             "flags": {
               "isOptional": false,
             },
             "name": "ComponentClass",
+            "typeName": "WrapperClass",
           },
         ],
         "returnType": {
@@ -793,6 +925,36 @@ exports[`documenter output > selectors 1`] = `
         },
       },
       {
+        "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+        "name": "findAllComponents",
+        "parameters": [
+          {
+            "flags": {
+              "isOptional": false,
+            },
+            "name": "ComponentClass",
+            "typeName": "ComponentWrapperClass",
+          },
+          {
+            "flags": {
+              "isOptional": true,
+            },
+            "name": "selector",
+          },
+        ],
+        "returnType": {
+          "name": "MultiElementWrapper",
+          "type": "reference",
+          "typeArguments": [
+            {
+              "name": "Wrapper",
+              "type": "typeParameter",
+            },
+          ],
+        },
+      },
+      {
         "name": "findByClassName",
         "parameters": [
           {
@@ -809,9 +971,14 @@ exports[`documenter output > selectors 1`] = `
         },
       },
       {
+        "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.
+",
         "name": "findComponent",
         "parameters": [
           {
+            "description": "
+CSS selector",
             "flags": {
               "isOptional": false,
             },
@@ -819,10 +986,13 @@ exports[`documenter output > selectors 1`] = `
             "typeName": "string",
           },
           {
+            "description": "
+Component's wrapper class",
             "flags": {
               "isOptional": false,
             },
             "name": "ComponentClass",
+            "typeName": "WrapperClass",
           },
         ],
         "returnType": {
@@ -937,6 +1107,39 @@ exports[`documenter output > selectors 1`] = `
         },
       },
       {
+        "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+        "inheritedFrom": {
+          "name": "AbstractWrapper.findAllComponents",
+        },
+        "name": "findAllComponents",
+        "parameters": [
+          {
+            "flags": {
+              "isOptional": false,
+            },
+            "name": "ComponentClass",
+            "typeName": "ComponentWrapperClass",
+          },
+          {
+            "flags": {
+              "isOptional": true,
+            },
+            "name": "selector",
+          },
+        ],
+        "returnType": {
+          "name": "MultiElementWrapper",
+          "type": "reference",
+          "typeArguments": [
+            {
+              "name": "Wrapper",
+              "type": "typeParameter",
+            },
+          ],
+        },
+      },
+      {
         "inheritedFrom": {
           "name": "AbstractWrapper.findByClassName",
         },
@@ -956,12 +1159,17 @@ exports[`documenter output > selectors 1`] = `
         },
       },
       {
+        "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.
+",
         "inheritedFrom": {
           "name": "AbstractWrapper.findComponent",
         },
         "name": "findComponent",
         "parameters": [
           {
+            "description": "
+CSS selector",
             "flags": {
               "isOptional": false,
             },
@@ -969,10 +1177,13 @@ exports[`documenter output > selectors 1`] = `
             "typeName": "string",
           },
           {
+            "description": "
+Component's wrapper class",
             "flags": {
               "isOptional": false,
             },
             "name": "ComponentClass",
+            "typeName": "WrapperClass",
           },
         ],
         "returnType": {
@@ -1096,6 +1307,39 @@ exports[`documenter output > selectors 1`] = `
         },
       },
       {
+        "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+        "inheritedFrom": {
+          "name": "AbstractWrapper.findAllComponents",
+        },
+        "name": "findAllComponents",
+        "parameters": [
+          {
+            "flags": {
+              "isOptional": false,
+            },
+            "name": "ComponentClass",
+            "typeName": "ComponentWrapperClass",
+          },
+          {
+            "flags": {
+              "isOptional": true,
+            },
+            "name": "selector",
+          },
+        ],
+        "returnType": {
+          "name": "MultiElementWrapper",
+          "type": "reference",
+          "typeArguments": [
+            {
+              "name": "Wrapper",
+              "type": "typeParameter",
+            },
+          ],
+        },
+      },
+      {
         "inheritedFrom": {
           "name": "AbstractWrapper.findByClassName",
         },
@@ -1115,12 +1359,17 @@ exports[`documenter output > selectors 1`] = `
         },
       },
       {
+        "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.
+",
         "inheritedFrom": {
           "name": "AbstractWrapper.findComponent",
         },
         "name": "findComponent",
         "parameters": [
           {
+            "description": "
+CSS selector",
             "flags": {
               "isOptional": false,
             },
@@ -1128,10 +1377,13 @@ exports[`documenter output > selectors 1`] = `
             "typeName": "string",
           },
           {
+            "description": "
+Component's wrapper class",
             "flags": {
               "isOptional": false,
             },
             "name": "ComponentClass",
+            "typeName": "WrapperClass",
           },
         ],
         "returnType": {
@@ -1255,6 +1507,39 @@ exports[`documenter output > selectors 1`] = `
         },
       },
       {
+        "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+        "inheritedFrom": {
+          "name": "AbstractWrapper.findAllComponents",
+        },
+        "name": "findAllComponents",
+        "parameters": [
+          {
+            "flags": {
+              "isOptional": false,
+            },
+            "name": "ComponentClass",
+            "typeName": "ComponentWrapperClass",
+          },
+          {
+            "flags": {
+              "isOptional": true,
+            },
+            "name": "selector",
+          },
+        ],
+        "returnType": {
+          "name": "MultiElementWrapper",
+          "type": "reference",
+          "typeArguments": [
+            {
+              "name": "Wrapper",
+              "type": "typeParameter",
+            },
+          ],
+        },
+      },
+      {
         "inheritedFrom": {
           "name": "AbstractWrapper.findByClassName",
         },
@@ -1274,12 +1559,17 @@ exports[`documenter output > selectors 1`] = `
         },
       },
       {
+        "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.
+",
         "inheritedFrom": {
           "name": "AbstractWrapper.findComponent",
         },
         "name": "findComponent",
         "parameters": [
           {
+            "description": "
+CSS selector",
             "flags": {
               "isOptional": false,
             },
@@ -1287,10 +1577,13 @@ exports[`documenter output > selectors 1`] = `
             "typeName": "string",
           },
           {
+            "description": "
+Component's wrapper class",
             "flags": {
               "isOptional": false,
             },
             "name": "ComponentClass",
+            "typeName": "WrapperClass",
           },
         ],
         "returnType": {

--- a/src/core/test/dom.test.ts
+++ b/src/core/test/dom.test.ts
@@ -7,7 +7,12 @@ import { KeyCode } from '../utils';
 
 describe('DOM test utils', () => {
   let node: HTMLElement, wrapper: ElementWrapper;
+
   const CLASS_NAME = 'some-class';
+
+  const LIST_WITH_ITEMS_CLASS_NAME = 'list-with-items';
+  const LIST_WITHOUT_ITEMS_CLASS_NAME = 'list-without-items';
+  const LIST_ITEM_CLASS_NAME = 'list-item';
 
   beforeEach(() => {
     // create test HTML
@@ -27,6 +32,19 @@ describe('DOM test utils', () => {
         <button>2</button>
         <button>2</button>
       </div>
+      <ul class="${LIST_WITH_ITEMS_CLASS_NAME}">
+        <li class="${LIST_ITEM_CLASS_NAME} first-type">1</li>
+        <li class="${LIST_ITEM_CLASS_NAME} second-type">2</li>
+        <li>
+          <ul>
+            <li class="${LIST_ITEM_CLASS_NAME} second-type">2.1</li>
+          </ul>
+        </li>
+      </ul>
+      <ul class="${LIST_WITHOUT_ITEMS_CLASS_NAME}">
+        <li class="some-other-item-type">1</li>
+        <li class="some-other-item-type">2</li>
+      </ul>
     `;
     document.body.appendChild(node);
 
@@ -210,7 +228,40 @@ describe('DOM test utils', () => {
         expect(result).toEqual(null);
       });
     });
+
+    describe('findAllComponents()', () => {
+      class ListItemWrapper extends ComponentWrapper<HTMLUListElement> {
+        static rootSelector = LIST_ITEM_CLASS_NAME;
+      }
+
+      it('returns an array of all components matching the wrapper class', () => {
+        const nodeWithListItemComponents = node.querySelector(`.${LIST_WITH_ITEMS_CLASS_NAME}`)!;
+        const wrapper = createWrapper(nodeWithListItemComponents);
+        const listItems = wrapper.findAllComponents(ListItemWrapper);
+        const listItemsContent = listItems.map(wrapper => wrapper.getElement().textContent);
+
+        expect(listItemsContent).toEqual(['1', '2', '2.1']);
+      });
+
+      it('returns an array of all components matching the wrapper class and the specified selector', () => {
+        const nodeWithListItemComponents = node.querySelector(`.${LIST_WITH_ITEMS_CLASS_NAME}`)!;
+        const wrapper = createWrapper(nodeWithListItemComponents);
+        const listItems = wrapper.findAllComponents(ListItemWrapper, '.second-type');
+        const listItemsContent = listItems.map(wrapper => wrapper.getElement().textContent);
+
+        expect(listItemsContent).toEqual(['2', '2.1']);
+      });
+
+      it('returns an empty array if no component was found', () => {
+        const nodeWithoutListItemComponents = node.querySelector(`.${LIST_WITHOUT_ITEMS_CLASS_NAME}`)!;
+        const wrapper = createWrapper(nodeWithoutListItemComponents);
+        const listItems = wrapper.findAllComponents(ListItemWrapper, '.second-type');
+
+        expect(listItems).toHaveLength(0);
+      });
+    });
   });
+
   describe('createWrapper', () => {
     test('returns an ElementWrapper of the document body', () => {
       const actual = createWrapper().getElement();

--- a/src/core/test/selectors.test.ts
+++ b/src/core/test/selectors.test.ts
@@ -11,9 +11,15 @@ class TestComponentWrapper extends ElementWrapper {
   findSingleChild() {
     return this.findComponent('awsui-child', ChildComponentWrapper);
   }
+
+  findAllChildren(selector?: string) {
+    return this.findAllComponents(ChildComponentWrapper, selector);
+  }
 }
 
 class ChildComponentWrapper extends ElementWrapper {
+  static rootSelector = 'awsui-child';
+
   findTitle() {
     return this.find('.title');
   }
@@ -60,6 +66,18 @@ describe('CSS-selectors test utils', () => {
 
   it('allows to find components', () => {
     expect(wrapper.findSingleChild().findTitle().toSelector()).toEqual('.awsui-component awsui-child .title');
+  });
+
+  it('allows to find nth-child of the same type components', () => {
+    expect(wrapper.findAllChildren().get(2).findTitle().toSelector()).toEqual(
+      '.awsui-component .awsui-child:nth-child(2) .title'
+    );
+  });
+
+  it('allows to find nth-child of the same type components matching the specified selector', () => {
+    expect(wrapper.findAllChildren('.some-class[data-some-attribute]').get(2).findTitle().toSelector()).toEqual(
+      '.awsui-component .awsui-child.some-class[data-some-attribute]:nth-child(2) .title'
+    );
   });
 
   it('converts css scoped selectors to wildcard classname selectors', () => {


### PR DESCRIPTION
*Issue #, if available:* **Test utils API improvements project**

Followed by: https://github.com/cloudscape-design/components/pull/2932

*Description of changes:*

Adds `findAllComponents` selector. This selector is used in the components test utils to generate `findAll[COMPONENT_NAME]s` selectors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
