### PR TITLE
chore: Fix deprecation warning

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,6 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 # Section for git-secrets
 
 if ! command -v git-secrets > /dev/null 2>&1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,4 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx --no-install lint-staged
-
-
 
 # Section for git-secrets
 

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,8 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-
-
 # Section for git-secrets
 
 if ! command -v git-secrets > /dev/null 2>&1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix this

```
husky - DEPRECATED

Please remove the following two lines from ./.husky/pre-commit:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0
```

Tested after the change, the git hooks still run


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
