### PR TITLE
chore: Support legacy root selector

### DIFF
--- a/src/converter/generate-component-finders.ts
+++ b/src/converter/generate-component-finders.ts
@@ -10,7 +10,10 @@ export { ${wrapperName} };`;
 
 const componentFinders = ({ name, wrapperName, pluralName }: ComponentWrapperMetadata) => `
 ElementWrapper.prototype.find${name} = function(selector) {
-  const rootSelector = \`.$\{${wrapperName}.rootSelector}\`;
+  let rootSelector = \`.$\{${wrapperName}.rootSelector}\`;
+  if("legacyRootSelector" in ${wrapperName} && ${wrapperName}.legacyRootSelector){
+    rootSelector = \`:is(.$\{${wrapperName}.rootSelector}, .$\{${wrapperName}.legacyRootSelector})\`;
+  }
   // casting to 'any' is needed to avoid this issue with generics
   // https://github.com/microsoft/TypeScript/issues/29132
   return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ${wrapperName});

--- a/src/converter/test/__snapshots__/test-utils-generator-snapshot.test.ts.snap
+++ b/src/converter/test/__snapshots__/test-utils-generator-snapshot.test.ts.snap
@@ -62,7 +62,10 @@ findAllTestComponentBs(selector?: string): Array<TestComponentBWrapper>;
 
 
 ElementWrapper.prototype.findTestComponentA = function(selector) {
-  const rootSelector = \`.\${TestComponentAWrapper.rootSelector}\`;
+  let rootSelector = \`.\${TestComponentAWrapper.rootSelector}\`;
+  if("legacyRootSelector" in TestComponentAWrapper && TestComponentAWrapper.legacyRootSelector){
+    rootSelector = \`:is(.\${TestComponentAWrapper.rootSelector}, .\${TestComponentAWrapper.legacyRootSelector})\`;
+  }
   // casting to 'any' is needed to avoid this issue with generics
   // https://github.com/microsoft/TypeScript/issues/29132
   return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TestComponentAWrapper);
@@ -72,7 +75,10 @@ ElementWrapper.prototype.findAllTestComponentAs = function(selector) {
   return this.findAllComponents(TestComponentAWrapper, selector);
 };
 ElementWrapper.prototype.findTestComponentB = function(selector) {
-  const rootSelector = \`.\${TestComponentBWrapper.rootSelector}\`;
+  let rootSelector = \`.\${TestComponentBWrapper.rootSelector}\`;
+  if("legacyRootSelector" in TestComponentBWrapper && TestComponentBWrapper.legacyRootSelector){
+    rootSelector = \`:is(.\${TestComponentBWrapper.rootSelector}, .\${TestComponentBWrapper.legacyRootSelector})\`;
+  }
   // casting to 'any' is needed to avoid this issue with generics
   // https://github.com/microsoft/TypeScript/issues/29132
   return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TestComponentBWrapper);
@@ -150,7 +156,10 @@ findAllTestComponentBs(selector?: string): MultiElementWrapper<TestComponentBWra
 
 
 ElementWrapper.prototype.findTestComponentA = function(selector) {
-  const rootSelector = \`.\${TestComponentAWrapper.rootSelector}\`;
+  let rootSelector = \`.\${TestComponentAWrapper.rootSelector}\`;
+  if("legacyRootSelector" in TestComponentAWrapper && TestComponentAWrapper.legacyRootSelector){
+    rootSelector = \`:is(.\${TestComponentAWrapper.rootSelector}, .\${TestComponentAWrapper.legacyRootSelector})\`;
+  }
   // casting to 'any' is needed to avoid this issue with generics
   // https://github.com/microsoft/TypeScript/issues/29132
   return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TestComponentAWrapper);
@@ -160,7 +169,10 @@ ElementWrapper.prototype.findAllTestComponentAs = function(selector) {
   return this.findAllComponents(TestComponentAWrapper, selector);
 };
 ElementWrapper.prototype.findTestComponentB = function(selector) {
-  const rootSelector = \`.\${TestComponentBWrapper.rootSelector}\`;
+  let rootSelector = \`.\${TestComponentBWrapper.rootSelector}\`;
+  if("legacyRootSelector" in TestComponentBWrapper && TestComponentBWrapper.legacyRootSelector){
+    rootSelector = \`:is(.\${TestComponentBWrapper.rootSelector}, .\${TestComponentBWrapper.legacyRootSelector})\`;
+  }
   // casting to 'any' is needed to avoid this issue with generics
   // https://github.com/microsoft/TypeScript/issues/29132
   return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TestComponentBWrapper);

--- a/src/converter/test/mock-test-utils/dom/test-component-a/index.ts
+++ b/src/converter/test/mock-test-utils/dom/test-component-a/index.ts
@@ -3,7 +3,8 @@
 import { ComponentWrapper, createWrapper } from '@cloudscape-design/test-utils-core/dom';
 
 export default class TestComponentAWrapper extends ComponentWrapper {
-  static rootSelector = 'test-component-a-root';
+  static rootSelector = 'awsui_button_1ueyk_1xee3_5';
+  static legacyRootSelector = 'awsui_button_2oldf_2oldf_5';
 
   findChild() {
     return createWrapper().find('.test-component-a-child');

--- a/src/converter/test/test-utils-generator.test.tsx
+++ b/src/converter/test/test-utils-generator.test.tsx
@@ -8,7 +8,7 @@ import { describe, test, expect } from 'vitest';
 function renderTestNode() {
   const { container } = render(
     <>
-      <div className="test-component-a-root">
+      <div className="awsui_button_1ueyk_1xee3_5">
         <h1 className="test-component-a-child">First Component A</h1>
       </div>
       <div className="test-component-b-root">
@@ -16,7 +16,7 @@ function renderTestNode() {
           <h1 className="test-component-b-child-content">First Component B</h1>
         </div>
       </div>
-      <div className="test-component-a-root">
+      <div className="awsui_button_2oldf_2oldf_5">
         <h1 className="test-component-a-child">Second Component A</h1>
       </div>
       <div className="test-component-b-root">
@@ -24,7 +24,7 @@ function renderTestNode() {
           <h1 className="test-component-b-child-content">Second Component B</h1>
         </div>
       </div>
-    </>
+    </>,
   );
   return container;
 }
@@ -77,10 +77,10 @@ describe(`${generateTestUtils.name}`, () => {
       const container = renderTestNode();
       const wrapper = createWrapper();
 
-      const secondComponentASelector = wrapper.findAllTestComponentAs().get(3).toSelector();
+      const secondComponentASelector = wrapper.findAllTestComponentAs().toSelector();
       const secondComponentBSelector = wrapper.findAllTestComponentBs().get(4).toSelector();
 
-      expect(container.querySelector(secondComponentASelector).textContent).toBe('Second Component A');
+      expect(container.querySelectorAll(secondComponentASelector)[1]!.textContent).toBe('Second Component A');
       expect(container.querySelector(secondComponentBSelector).textContent).toBe('Second Component B');
     });
   });

--- a/src/core/dom.ts
+++ b/src/core/dom.ts
@@ -29,6 +29,7 @@ interface WrapperClass<Wrapper, ElementType> {
 
 interface ComponentWrapperClass<Wrapper, ElementType> extends WrapperClass<Wrapper, ElementType> {
   rootSelector: string;
+  legacyRootSelector?: string;
 }
 
 export class AbstractWrapper<ElementType extends Element>
@@ -165,7 +166,10 @@ export class AbstractWrapper<ElementType extends Element>
     ComponentClass: ComponentWrapperClass<Wrapper, ElementType>,
     selector?: string,
   ): Array<Wrapper> {
-    const componentRootSelector = `.${ComponentClass.rootSelector}`;
+    let componentRootSelector = `.${ComponentClass.rootSelector}`;
+    if ('legacyRootSelector' in ComponentClass && ComponentClass.legacyRootSelector) {
+      componentRootSelector = `:is(.${ComponentClass.rootSelector}, .${ComponentClass.legacyRootSelector})`;
+    }
     const componentCombinedSelector = selector
       ? appendSelector(componentRootSelector, selector)
       : componentRootSelector;

--- a/src/core/selectors.ts
+++ b/src/core/selectors.ts
@@ -14,6 +14,7 @@ interface WrapperClass<Wrapper> {
 
 interface ComponentWrapperClass<Wrapper> extends WrapperClass<Wrapper> {
   rootSelector: string;
+  legacyRootSelector?: string;
 }
 
 export class AbstractWrapper implements IElementWrapper<string, MultiElementWrapper<ElementWrapper>> {
@@ -71,7 +72,10 @@ export class AbstractWrapper implements IElementWrapper<string, MultiElementWrap
     ComponentClass: ComponentWrapperClass<Wrapper>,
     selector?: string,
   ): MultiElementWrapper<Wrapper> {
-    const componentRootSelector = `.${ComponentClass.rootSelector}`;
+    let componentRootSelector = `.${ComponentClass.rootSelector}`;
+    if ('legacyRootSelector' in ComponentClass && ComponentClass.legacyRootSelector) {
+      componentRootSelector = `:is(.${ComponentClass.rootSelector}, .${ComponentClass.legacyRootSelector})`;
+    }
     const componentCombinedSelector = selector
       ? appendSelector(componentRootSelector, selector)
       : componentRootSelector;

--- a/src/core/test/dom.test.ts
+++ b/src/core/test/dom.test.ts
@@ -46,6 +46,10 @@ describe('DOM test utils', () => {
         <li class="some-other-item-type">1</li>
         <li class="some-other-item-type">2</li>
       </ul>
+      <div>
+        <div class="awsui_button_1ueyk_1xee3_5">New Button</div>
+        <div class="awsui_button_2oldf_2oldf_5">Old Button</div>
+      </div>
     `;
     document.body.appendChild(node);
 
@@ -266,6 +270,20 @@ describe('DOM test utils', () => {
         const listItems = wrapper.findAllComponents(ListItemWrapper, '.second-type');
 
         expect(listItems).toHaveLength(0);
+      });
+
+      it('handles findAllComponents with legacyRootSelector', () => {
+        class MockComponentWrapper extends ComponentWrapper {
+          static rootSelector = 'awsui_button_1ueyk_1xee3_5';
+          static legacyRootSelector = 'awsui_button_2oldf_2oldf_5';
+        }
+
+        const wrapper = createWrapper();
+        const components = wrapper.findAllComponents(MockComponentWrapper);
+
+        expect(components).toHaveLength(2);
+        expect(components[0].getElement().textContent).toBe('New Button');
+        expect(components[1].getElement().textContent).toBe('Old Button');
       });
     });
   });

--- a/src/core/test/selectors.test.ts
+++ b/src/core/test/selectors.test.ts
@@ -109,6 +109,31 @@ describe('CSS-selectors test utils', () => {
         .toSelector(),
     ).toEqual('.awsui-component [class*="awsui_button_filenameHash"][class*="awsui_button-active_filenameHash"]');
   });
+
+  it('handles findAllComponents with legacyRootSelector', () => {
+    class MockComponentWrapper extends ElementWrapper {
+      static rootSelector = 'awsui_button_1ueyk_1xee3_5';
+      static legacyRootSelector = 'awsui_button_2oldf_2oldf_5';
+    }
+
+    const multiWrapper = wrapper.findAllComponents(MockComponentWrapper);
+    expect(multiWrapper.toSelector()).toBe(
+      '.awsui-component :is([class*="awsui_button_1ueyk"], [class*="awsui_button_2oldf"])',
+    );
+  });
+
+  it('handles MultiElementWrapper get() with :is() selector', () => {
+    class MockComponentWrapper extends ElementWrapper {
+      static rootSelector = 'awsui_button_1ueyk_1xee3_5';
+      static legacyRootSelector = 'awsui_button_2oldf_2oldf_5';
+    }
+
+    const multiWrapper = wrapper.findAllComponents(MockComponentWrapper);
+    const secondElement = multiWrapper.get(2);
+    expect(secondElement.toSelector()).toBe(
+      '.awsui-component :is([class*="awsui_button_1ueyk"], [class*="awsui_button_2oldf"]):nth-child(2)',
+    );
+  });
 });
 
 describe('createWrapper', () => {

--- a/src/core/test/utils.test.ts
+++ b/src/core/test/utils.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { describe, test, expect } from 'vitest';
-import { appendSelector } from '../utils';
+import { describe, test, it, expect } from 'vitest';
+import { appendSelector, getUnscopedClassName } from '../utils';
 
 describe('appendSelector', () => {
   test('appends selectors', () => {
@@ -23,6 +23,54 @@ describe('appendSelector', () => {
   test('throws error when additional string is a cascade selector', () => {
     expect(() => appendSelector('.button', '.selected .icon')).toThrow(
       /Appended selector may not contain a combinator/,
+    );
+  });
+});
+
+describe('getUnscopedClassName', () => {
+  it('transforms scoped class names to attribute selectors', () => {
+    expect(getUnscopedClassName('.awsui_button_1ueyk_1xee3_5')).toBe('[class*="awsui_button_1ueyk"]');
+  });
+
+  it('leaves non-scoped class names unchanged', () => {
+    expect(getUnscopedClassName('.regular-class')).toBe('.regular-class');
+  });
+
+  it('handles :is() with scoped classes', () => {
+    expect(getUnscopedClassName(':is(.awsui_button_1ueyk_1xee3_5, .awsui_button_1xzyz_1xdd2_3)')).toBe(
+      ':is([class*="awsui_button_1ueyk"], [class*="awsui_button_1xzyz"])',
+    );
+  });
+
+  it('leaves :is() with non-scoped classes unchanged', () => {
+    expect(getUnscopedClassName(':is(.awsui-first, .awsui-second)')).toBe(':is(.awsui-first, .awsui-second)');
+  });
+
+  it('handles complex selector with :is() and additional content', () => {
+    expect(
+      getUnscopedClassName(
+        '.awsui-component :is(.awsui_button_1ueyk_1xee3_5, .awsui_button_1xyzy_1xdd2_3) .awsui_inner_1ueyk_1xee3_5',
+      ),
+    ).toBe(
+      '.awsui-component :is([class*="awsui_button_1ueyk"], [class*="awsui_button_1xyzy"]) [class*="awsui_inner_1ueyk"]',
+    );
+  });
+
+  it('handles :is() with pseudo-classes', () => {
+    expect(getUnscopedClassName(':is(.awsui_button_1ueyk_1xee3_5, .awsui_old):hover')).toBe(
+      ':is([class*="awsui_button_1ueyk"], .awsui_old):hover',
+    );
+  });
+
+  it('handles multiple :is() in one selector', () => {
+    expect(getUnscopedClassName(':is(.awsui_button_1ueyk_1xee3_5):hover :is(.awsui_icon_1xyzy_1xdd2_3)')).toBe(
+      ':is([class*="awsui_button_1ueyk"]):hover :is([class*="awsui_icon_1xyzy"])',
+    );
+  });
+
+  it('handles mixed scoped and non-scoped classes in :is()', () => {
+    expect(getUnscopedClassName(':is(.regular-class, .awsui_button_1ueyk_1xee3_5, .another-class)')).toBe(
+      ':is(.regular-class, [class*="awsui_button_1ueyk"], .another-class)',
     );
   });
 });


### PR DESCRIPTION
*Issue #, if available:* AWSUI-61212

*Description of changes:*

Support legacy root selector, fix the situation where test package has been updated with new selector while asset is still consuming old package with old selector. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
