### PR TITLE
chore: removing unnecessary eslint-plugin-header schema validation workaround

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,9 +7,6 @@ const headerPlugin = require('@tony.ganchev/eslint-plugin-header');
 const prettierPlugin = require('eslint-plugin-prettier');
 const prettierConfig = require('eslint-config-prettier');
 
-// https://github.com/Stuk/eslint-plugin-header/issues/57
-headerPlugin.rules.header.meta.schema = false;
-
 module.exports = [
   {
     ignores: ['node_modules/**', 'lib/**', '**/dist/**', 'src/converter/test/outputs/**', 'test/mock-test-utils/**'],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The schema turn-off was only necessary with the original _eslint-plugin-header_ and was addressed in _@tony.ganchev/eslint-plugin-header_ fork.

The change was leftover from https://github.com/cloudscape-design/test-utils/pull/114/.