### PR TITLE
fix: rewrite re-export sources to selectors

### DIFF
--- a/src/converter/convert-to-selectors.ts
+++ b/src/converter/convert-to-selectors.ts
@@ -10,6 +10,14 @@ interface PluginArguments {
   types: typeof types;
 }
 
+// Rewrites a `@cloudscape-design/.../dom` module path to `.../selectors`.
+function rewriteDomSourceToSelectors(source: NodePath<types.StringLiteral>, t: typeof types) {
+  const value = source.node.value;
+  if (value.startsWith('@cloudscape-design/')) {
+    source.replaceWith(t.stringLiteral(value.replace(/\b\/dom\b/, '/selectors')));
+  }
+}
+
 function selectorUtilsGenerator({ types: t }: PluginArguments): PluginObj {
   return {
     visitor: {
@@ -17,10 +25,7 @@ function selectorUtilsGenerator({ types: t }: PluginArguments): PluginObj {
         const source = path.get('source');
 
         // Rewrite import path @cloudscape-design/.../dom -> @cloudscape-design/.../selectors
-        if (source.node.value.startsWith('@cloudscape-design/')) {
-          const newImportPath = source.node.value.replace(/\b\/dom\b/, '/selectors');
-          source.replaceWith(t.stringLiteral(newImportPath));
-        }
+        rewriteDomSourceToSelectors(source, t);
 
         // Remove @usesDom decorator
         if (source.node.value === runtimeSelectorsPath) {
@@ -34,6 +39,15 @@ function selectorUtilsGenerator({ types: t }: PluginArguments): PluginObj {
         if (source.node.value === domUtilsPath) {
           path.remove();
         }
+      },
+      // Re-exports need the same rewrite as imports. Local exports have no source.
+      ExportNamedDeclaration(path: NodePath<types.ExportNamedDeclaration>) {
+        if (path.node.source) {
+          rewriteDomSourceToSelectors(path.get('source') as NodePath<types.StringLiteral>, t);
+        }
+      },
+      ExportAllDeclaration(path: NodePath<types.ExportAllDeclaration>) {
+        rewriteDomSourceToSelectors(path.get('source'), t);
       },
       ClassDeclaration(path: NodePath<types.ClassDeclaration>) {
         // our wrapper classes have generic parameters only in DOM version

--- a/src/converter/test/__snapshots__/converter.test.ts.snap
+++ b/src/converter/test/__snapshots__/converter.test.ts.snap
@@ -18,6 +18,21 @@ export default class DummyWrapper extends ComponentWrapper {
 }"
 `;
 
+exports[`reexport-source 1`] = `
+"// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Proxied wrappers are often written as re-exports, so the \`/dom\` -> \`/selectors\`
+// rewrite has to apply to re-export sources too, not just imports.
+export { default } from "@cloudscape-design/components/test-utils/selectors/button";
+export * from "@cloudscape-design/components/test-utils/selectors/container";
+
+// Local exports have no module source, so they stay as-is.
+const value = 1;
+export { value };
+export default value;"
+`;
+
 exports[`simple 1`] = `
 "// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0

--- a/src/converter/test/inputs/converter-no-typecheck/reexport-source.ts
+++ b/src/converter/test/inputs/converter-no-typecheck/reexport-source.ts
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Proxied wrappers are often written as re-exports, so the `/dom` -> `/selectors`
+// rewrite has to apply to re-export sources too, not just imports.
+export { default } from '@cloudscape-design/components/test-utils/dom/button';
+export * from '@cloudscape-design/components/test-utils/dom/container';
+
+// Local exports have no module source, so they stay as-is.
+const value = 1;
+export { value };
+export default value;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

### Description

The selectors converter only rewrote module paths on import declarations, so re-export
declarations pointing at a Cloudscape `/dom` entry were left alone. A wrapper written as
`export { default } from '@cloudscape-design/components/test-utils/dom/button'` produced a
selectors variant that still pointed at the DOM wrapper, which breaks selectors generation for
consumers that build their own scoped test-utils.

This PR applies the same `/dom` -> `/selectors` rewrite to `ExportNamedDeclaration` and
`ExportAllDeclaration` sources. The shared logic moved into a small helper so imports and
re-exports stay in sync. Local exports such as `export { value }` and `export default value` have
no module source and are left untouched.

### How has this been tested?

Added a converter input at `src/converter/test/inputs/converter-no-typecheck/reexport-source.ts`
that covers both re-export forms (`export { default } from ...` and `export * from ...`) next to
plain local exports, so one snapshot pins both halves of the behavior: the re-export sources get
rewritten, and the local exports are left alone.

Reviewers can run `npm test` (11 files, 92 tests) and read the new `reexport-source 1` entry in
`src/converter/test/__snapshots__/converter.test.ts.snap`, where the two re-exports now resolve to
`.../test-utils/selectors/button` and `.../test-utils/selectors/container`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
