### PR TITLE
chore: Remediate 2 Dependabot security alerts (lockfile only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1951,15 +1951,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/brace-expansion/node_modules/balanced-match": {


### PR DESCRIPTION
## Automated Dependabot security-alert remediation

Alert-driven remediation of this repository's **open** Dependabot security alerts.
Baseline: `43f97ee7a` on `main`.

### Alerts resolved (2 of 2)

| Alert | Sev | Package | Major line | Vulnerable range | First patched | Now resolved to | Advisory |
|---|---|---|---|---|---|---|---|
| #104 | high | `brace-expansion` | 5.x | `>= 4.0.0, < 5.0.8` | 5.0.8 | `5.0.9` | [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (CVE-2026-14257) |
| #105 | high | `brace-expansion` | 5.x | `>= 4.0.0, < 5.0.9` | 5.0.9 | `5.0.9` | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) (CVE-2026-69152) |

### How this was remediated

* **Rung 1 — `npm audit fix --package-lock-only --ignore-scripts`** (no `--force` was used anywhere in this run).
* The repo's own `prepare-package-lock` convention (`postinstall` in `@cloudscape-design/build-tools`) was applied afterwards, so no `@cloudscape-design/*` entries are (re-)introduced into the lockfile.
* npm's full reconciliation additionally healed unrelated pre-existing lockfile drift (stale entries, `dev`/`optional` flags, unrelated minor bumps). **That collateral was deliberately discarded**: only the security-relevant entries from npm's computed result were applied on top of the committed lockfile, so this diff contains alert-driven changes only.
* Verified with `npm ls --package-lock-only --all`: **zero new** unmet/invalid dependency problems versus `main`.

### Lockfile changes (1)

| Package | From | To | Scope | Lockfile path |
|---|---|---|---|---|
| `brace-expansion` | 5.0.7 | 5.0.9 | **non-dev** | `node_modules/brace-expansion` |

### NPMPM (NpmPrettyMuch) availability — internal build safety

Every **non-dev** lockfile dependency whose version increased was checked on `npmpm.corp.amazon.com` (the `NpmPrettyMuch` column specifically):

| Package | Version | NpmPrettyMuch status | Verdict |
|---|---|---|---|
| [`brace-expansion`](https://npmpm.corp.amazon.com/pkg/brace-expansion) | [5.0.9](https://npmpm.corp.amazon.com/pkg/brace-expansion/5.0.9) | `✓ exists` | **AVAILABLE** |

**Result: 1/1 AVAILABLE, 0 pending, 0 blocked/unknown.** No internal-build (Brazil) impact expected; the NPMPM availability check should come back green.

### Does merging clear this repository's alert list?

**Yes.** Merging this PR is expected to close **all 2** of this repository's currently-open Dependabot security alerts.

---

<sub>Existing Dependabot-authored PRs were deliberately **not** touched, reviewed, rebased, or closed by this run.</sub>

> Opened by roko-dependabot on behalf of @ernst-dev. Alert-driven remediation; not merged — a human must review and merge.
